### PR TITLE
Fix panic on device disconnect and add camera mode detection

### DIFF
--- a/100-playstation-camera.rules
+++ b/100-playstation-camera.rules
@@ -1,1 +1,5 @@
+# PlayStation 5 Camera - Bootloader mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="05a9", ATTRS{idProduct}=="0580", GROUP="plugdev", MODE="0660"
+
+# PlayStation 5 Camera - Working mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="05a9", ATTRS{idProduct}=="058c", GROUP="plugdev", MODE="0660"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 This tool is used to install firmware onto a Playstation camera. The supported models are listed below.
 
-| Model number | Console |
-|--------------|---------|
-| CUH-ZEY1     | [PS4](./docs/ps4-camera-image.jpg)     |
-| CFI-ZEY1     | [PS5](./docs/ps5-camera-image.jpg)     |
+| Model number | Console                            |
+| ------------ | ---------------------------------- |
+| CUH-ZEY1     | [PS4](./docs/ps4-camera-image.jpg) |
+| CFI-ZEY1     | [PS5](./docs/ps5-camera-image.jpg) |
 
 The PlayStation 2 camera (["EyeToy"/SLEH-0003x variants](./docs/ps2-camera-image.jpg)) and PlayStation 3 camera (["PlayStation Eye"/SLEH-00448](.docs/ps3-camera-image.png)) use UVC drivers by default, and do not have the ability to program firmware over USB.
 
@@ -24,8 +24,8 @@ To use this as a webcam, we need to install custom firmware onto the device (the
 
 You can find custom firmware for the Playstation camera on Github, here's a few that I've used:
 
-* <https://github.com/prosperodev/hdcamera/blob/main/firmware/21.01-03.20.00.04-00.00.00.bin>
-* <https://github.com/Hackinside/PS5_camera_files/blob/main/firmware.bin>
+- <https://github.com/prosperodev/hdcamera/blob/main/firmware/21.01-03.20.00.04-00.00.00.bin>
+- <https://github.com/Hackinside/PS5_camera_files/blob/main/firmware.bin>
 
 (Many more firmware versions are available [here](https://github.com/psxdev/luke_firmwares))
 
@@ -72,7 +72,7 @@ $ cargo build --manifest-path=Cargo.toml
 $ ./target/debug/ps5_camera_firmware_loader <firmware-file-path>
 ```
 
-## Success  :heavy_check_mark:
+## Success :heavy_check_mark:
 
 Go back to the dmesg window from earlier. You should see the following line:
 
@@ -86,7 +86,7 @@ To have the firmware automatically installed at startup time, you can use this r
 
 Here's a test image from the PS5 camera:
 
-![test-image](./ps5-camera-test-image.jpg)
+![test-image](./docs/ps5-camera-test-image.jpg)
 
 If you're using the firmware that I linked to above, then these are the formats and parameters it supports:
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ps5_camera_firmware_loader"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Raleigh Littles <raleighlittles@ucsb.edu>"]
 edition = "2021"
 description = "A tool for installing firmware on the Playstation 4 or 5 camera"
-repository = "https://github.com/raleighlittles/PS5-Camera-Firmware-Loader/"
+repository = "https://github.com/raleighlittles/PlayStation-Camera-Firmware-Loader"
 readme = "../README.md"
 license = "MIT"
 keywords = ["playstation", "ps4_camera", "ps5_camera", "omnivision", "uvc"]


### PR DESCRIPTION
Changes:
- Replace .unwrap() calls with proper error handling using match expressions
- Add support for detecting camera in both bootloader (0x0580) and working (0x058c) modes
- Handle NoDevice error gracefully when camera disconnects after firmware upload
- Provide clear user feedback for all scenarios (bootloader, already programmed, not found)

Previously, the program would panic in two cases:
1. After successful firmware upload when the camera reboots (NoDevice error on footer packet)
2. When trying to flash an already-programmed camera (None from open_device_with_vid_pid)

Now the program exits cleanly with appropriate messages in all cases, making it safe to run multiple times without errors.

Fixes panic on line 12 and line 116 when camera is in unexpected state.